### PR TITLE
Added Configurable Time Units for "artifactCleanup"

### DIFF
--- a/cleanup/artifactCleanup/ArtifactCleanupTest.groovy
+++ b/cleanup/artifactCleanup/ArtifactCleanupTest.groovy
@@ -39,6 +39,35 @@ class ArtifactCleanupTest extends Specification {
         when:
         artifactory.plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').sync()
+        artifactory.repository('maven-local').file('test').info()
+
+        then:
+        thrown(HttpResponseException)
+
+        cleanup:
+        artifactory.repository('maven-local').delete()
+    }
+
+    def 'artifact cleanup test using deprecated months parameter'() {
+        setup:
+        def artifactory = createClientAndMavenRepo('maven-local')
+
+        def file = new ByteArrayInputStream('test'.bytes)
+        artifactory.repository('maven-local').upload('test', file).doUpload()
+
+        when:
+        artifactory.plugins().execute('cleanup').
+            withParameter('repos', 'maven-local').sync()
+        artifactory.repository('maven-local').file('test').info()
+
+        then:
+        notThrown(HttpResponseException)
+
+        when:
+        artifactory.plugins().execute('cleanup').
+            withParameter('repos', 'maven-local').
             withParameter('months', '0').sync()
         artifactory.repository('maven-local').file('test').info()
 
@@ -59,7 +88,8 @@ class ArtifactCleanupTest extends Specification {
         when:
         artifactory.plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
-            withParameter('months', '0').sync()
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').sync()
         artifactory.repository('maven-local').file('test').info()
 
         then:
@@ -68,7 +98,8 @@ class ArtifactCleanupTest extends Specification {
         when:
         artifactory.plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
-            withParameter('months', '0').
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').
             withParameter('disablePropertiesSupport', 'true').sync()
         artifactory.repository('maven-local').file('test').info()
 
@@ -92,7 +123,8 @@ class ArtifactCleanupTest extends Specification {
         artifactory.repository('maven-local').folder('foo/bar').properties().addProperty('cleanup.skip', 'true').doSet()
         artifactory.plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
-            withParameter('months', '0').sync()
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').sync()
         artifactory.repository('maven-local').file('foo/bar/test').info()
 
         then:
@@ -106,7 +138,8 @@ class ArtifactCleanupTest extends Specification {
         artifactory.repository('maven-local').folder('foo').properties().addProperty('cleanup.skip', 'true').doSet()
         artifactory.plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
-            withParameter('months', '0').sync()
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').sync()
         artifactory.repository('maven-local').file('foo/bar/test').info()
 
         then:
@@ -120,7 +153,8 @@ class ArtifactCleanupTest extends Specification {
         artifactory.repository('maven-local').folder('foo/bar').properties().addProperty('cleanup.skip', 'true').doSet()
         artifactory.plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
-            withParameter('months', '0').sync()
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').sync()
         artifactory.repository('maven-local').file('foo/bar/test').info()
 
         then:
@@ -129,7 +163,8 @@ class ArtifactCleanupTest extends Specification {
         when:
         artifactory.plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
-            withParameter('months', '0').
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').
             withParameter('disablePropertiesSupport', 'true').sync()
         artifactory.repository('maven-local').file('foo/bar/test').info()
 
@@ -155,7 +190,8 @@ class ArtifactCleanupTest extends Specification {
         when:
         artifactory.plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
-            withParameter('months', '0').sync()
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').sync()
         artifactory.repository('maven-local').file('foobar/test').info()
 
         then:
@@ -189,7 +225,8 @@ class ArtifactCleanupTest extends Specification {
             .setUsername('nobody').setPassword('password').build().
             plugins().execute('cleanup').
             withParameter('repos', 'maven-local').
-            withParameter('months', '0').sync()
+            withParameter('timeUnit', 'month').
+            withParameter('timeInterval', '0').sync()
         artifactory.repository('maven-local').file('foo/bar/test').info()
 
         then:

--- a/cleanup/artifactCleanup/README.md
+++ b/cleanup/artifactCleanup/README.md
@@ -72,8 +72,7 @@ An example file could contain the following json:
 }
 ```
 
-**Note**: If a deprecated `artifactCleanup.properties` is defined it will be applied first and these policies may be overridden by policies defined in the `artifactCleanup.json`.
-
+**Note**: If a deprecated `artifactCleanup.properties` is defined it will only be applied if no `artifactCleanup.json` is present.
 
 Executing
 ---------

--- a/cleanup/artifactCleanup/README.md
+++ b/cleanup/artifactCleanup/README.md
@@ -1,9 +1,8 @@
 Artifactory Artifact Cleanup User Plugin
 ========================================
 
-This plugin deletes all artifacts that have not been downloaded for the past n
-months. It can be run manually from the REST API, or automatically as a
-scheduled job.
+This plugin deletes all artifacts that have not been downloaded for the past *n time units*,
+which is by default 1 month. It can be run manually from the REST API, or automatically as a scheduled job.
 
 Many delete operations can affect performance due to disk I/O occurring. A new parameter now allows a delay per delete operation. See below.
 
@@ -17,10 +16,12 @@ To ensure logging for this plugin, edit ${ARTIFACTORY_HOME}/etc/logback.xml to a
 Parameters
 ----------
 
-- `months`: The number of months back to look before deleting an artifact. Default 6.
+- `months`: **Deprecated**. Instead of `timeUnit` and `timeInterval` the `month` parameter is supported for backwards compatibility reasons. It defined the months to look back before deleting an artifact. Default *1*.
+- `timeUnit`: The unit of the time interval. *year*, *month*, *day*, *hour* or *minute* are allowed values. Default *month*.
+- `timeInterval`: The time interval to look back before deleting an artifact. Default *1*.
 - `repos`: A list of repositories to clean. This parameter is required.
-- `dryRun`: If this parameter is passed, artifacts will not actually be deleted.
-- `paceTimeMS`: The number of milliseconds to delay between delete operations. Default 0.
+- `dryRun`: If this parameter is passed, artifacts will not actually be deleted. Default *false*.
+- `paceTimeMS`: The number of milliseconds to delay between delete operations. Default *0*.
 - `disablePropertiesSupport`: Disable the support of Artifactory Properties (see below *Artifactory Properties support* section). Default *false*.
 
 Properties
@@ -38,15 +39,54 @@ Some Artifactory [Properties](https://www.jfrog.com/confluence/display/RTF/Prope
 - `cleanup.skip`: Skip the artifact deletion if property defined on artifact's path ; artifact itself or in a parent folder(s).
 
 
+`artifactCleanup.json`
+----------
+
+The json contains the policies for scheduling cleanup jobs for different repositories.
+
+The following properties are supported by each policy descriptor object:
+- `cron`: The cron time when the job is executed. Default `0 0 5 ? * 1` *should* be redefined.
+- `repos`: The mandatory list of repositories the policies will be applied to.
+- `timeUnit`: The unit of the time interval. *year*, *month*, *day*, *hour* or *minute* are allowed values. Default *month*.
+- `timeInterval`: The time interval to look back before deleting an artifact. Default *1*.
+- `dryRun`:  If this parameter is passed, artifacts will not actually be deleted. Default *false*.
+- `paceTimeMS`: The number of milliseconds to delay between delete operations. Default *0*.
+- `disablePropertiesSupport`: Disable the support of Artifactory Properties (see above *Artifactory Properties support* section).
+
+An example file could contain the following json:
+```json
+{
+    "policies": [
+        {
+            "cron": "0 0 1 ? * 1",
+            "repos": [
+                "libs-releases-local"
+            ],
+            "timeUnit": "day",
+            "timeInterval": 3,
+            "dryRun": true,
+            "paceTimeMS": 500,
+            "disablePropertiesSupport": true
+        }
+    ]
+}
+```
+
+**Note**: If a deprecated `artifactCleanup.properties` is defined it will be applied first and these policies may be overridden by policies defined in the `artifactCleanup.json`.
+
+
 Executing
 ---------
 
 To execute the plugin:
 
 For Artifactory 4.x: 
-`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanup?params=months=1|repos=libs-release-local|dryRun=true|paceTimeMS=2000|disablePropertiesSupport=true"`
+`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanup?params=timeUnit=month|timeInterval=1|repos=libs-release-local|dryRun=true|paceTimeMS=2000|disablePropertiesSupport=true"`
 
 For Artifactory 5.x or higher:
+`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanup?params=timeUnit=month;timeInterval=1;repos=libs-release-local;dryRun=true;paceTimeMS=2000;disablePropertiesSupport=true"`
+
+For Artifactory 5.x or higher, using the depracted `months` parameter:
 `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanup?params=months=1;repos=libs-release-local;dryRun=true;paceTimeMS=2000;disablePropertiesSupport=true"`
 
 Admin users and users inside the `cleaners` group can execute the plugin.

--- a/cleanup/artifactCleanup/artifactCleanup.groovy
+++ b/cleanup/artifactCleanup/artifactCleanup.groovy
@@ -17,11 +17,17 @@
 import org.apache.commons.lang3.StringUtils
 import org.artifactory.api.repo.exception.ItemNotFoundRuntimeException
 
+import groovy.json.JsonSlurper
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
 import groovy.transform.Field
 
+import java.text.SimpleDateFormat
+
+@Field final String CONFIG_FILE_PATH = "plugins/${this.class.name}.json"
 @Field final String PROPERTIES_FILE_PATH = "plugins/${this.class.name}.properties"
+@Field final String DEFAULT_TIME_UNIT = "month"
+@Field final int DEFAULT_TIME_INTERVAL = 1
 
 class Global {
     static Boolean stopCleaning = false
@@ -30,7 +36,7 @@ class Global {
 }
 
 // curl command example for running this plugin (Prior to Artifactory 5.x, use pipe '|' and not semi-colons ';' for parameters separation).
-// curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/cleanup?params=months=1;repos=libs-release-local;dryRun=true;paceTimeMS=2000;disablePropertiesSupport=true"
+// curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/cleanup?params=timeUnit=day;timeInterval=1;repos=libs-release-local;dryRun=true;paceTimeMS=2000;disablePropertiesSupport=true"
 //
 // For a HA cluster, the following commands have to be directed at the instance running the script. Therefore it is best to invoke
 // the script directly on an instance so the below commands can operate on same instance
@@ -43,12 +49,22 @@ def pluginGroup = 'cleaners'
 
 executions {
     cleanup(groups: [pluginGroup]) { params ->
-        def months = params['months'] ? params['months'][0] as int : 6
+        def timeUnit = params['timeUnit'] ? params['timeUnit'][0] as String : DEFAULT_TIME_UNIT
+        def timeInterval = params['timeInterval'] ? params['timeInterval'][0] as int : DEFAULT_TIME_INTERVAL
         def repos = params['repos'] as String[]
-        def dryRun = params['dryRun'] ? params['dryRun'][0] as boolean : false
-        def disablePropertiesSupport = params['disablePropertiesSupport'] ? params['disablePropertiesSupport'][0] as boolean : false
+        def dryRun = params['dryRun'] ? new Boolean(params['dryRun'][0]) : false
+        def disablePropertiesSupport = params['disablePropertiesSupport'] ? new Boolean(params['disablePropertiesSupport'][0]) : false
         Global.paceTimeMS = params['paceTimeMS'] ? params['paceTimeMS'][0] as int : 0
-        artifactCleanup(months, repos, log, Global.paceTimeMS, dryRun, disablePropertiesSupport)
+
+        // Enable fallback support for deprecated month parameter
+        if ( params['months'] && !params['timeInterval'] ) {
+            log.info('Deprecated month parameter is still in use, please use the new timeInterval parameter instead!', properties)
+            timeInterval = params['months'][0] as int
+        } else if ( params['months'] ) {
+            log.info('Deprecated month parameter and the new timeInterval are used in parallel: month has been ignored.', properties)
+        }
+
+        artifactCleanup(timeUnit, timeInterval, repos, log, Global.paceTimeMS, dryRun, disablePropertiesSupport)
     }
 
     cleanupCtl(groups: [pluginGroup]) { params ->
@@ -78,27 +94,61 @@ executions {
     }
 }
 
-def config = new ConfigSlurper().parse(new File(ctx.artifactoryHome.haAwareEtcDir, PROPERTIES_FILE_PATH).toURL())
-log.info "Schedule job policy list: $config.policies"
+def deprecatedConfigFile = new File(ctx.artifactoryHome.haAwareEtcDir, PROPERTIES_FILE_PATH)
+def configFile = new File(ctx.artifactoryHome.haAwareEtcDir, CONFIG_FILE_PATH)
 
-config.policies.each{ policySettings ->
-    def cron = policySettings[ 0 ] ? policySettings[ 0 ] as String : ["0 0 5 ? * 1"]
-    def repos = policySettings[ 1 ] ? policySettings[ 1 ] as String[] : ["__none__"]
-    def months = policySettings[ 2 ] ? policySettings[ 2 ] as int : 6
-    def paceTimeMS = policySettings[ 3 ] ? policySettings[ 3 ] as int : 0
-    def dryRun = policySettings[ 4 ] ? policySettings[ 4 ] as Boolean : false
-    def disablePropertiesSupport = policySettings[ 5 ] ? policySettings[ 5 ] as Boolean : false
+if ( deprecatedConfigFile.exists() ) {
 
-    jobs {
-        "scheduledCleanup_$cron"(cron: cron) {
-            log.info "Policy settings for scheduled run at($cron): repo list($repos), months($months), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport)"
-            artifactCleanup( months, repos, log, paceTimeMS, dryRun, disablePropertiesSupport )
+    def config = new ConfigSlurper().parse(deprecatedConfigFile.toURL())
+    log.info "Schedule job policy list: $config.policies"
+
+    config.policies.each{ policySettings ->
+        def cron = policySettings[ 0 ] ? policySettings[ 0 ] as String : ["0 0 5 ? * 1"]
+        def repos = policySettings[ 1 ] ? policySettings[ 1 ] as String[] : ["__none__"]
+        def months = policySettings[ 2 ] ? policySettings[ 2 ] as int : 6
+        def paceTimeMS = policySettings[ 3 ] ? policySettings[ 3 ] as int : 0
+        def dryRun = policySettings[ 4 ] ? policySettings[ 4 ] as Boolean : false
+        def disablePropertiesSupport = policySettings[ 5 ] ? policySettings[ 5 ] as Boolean : false
+
+        jobs {
+            "scheduledCleanup_$cron"(cron: cron) {
+                log.info "Policy settings for scheduled run at($cron): repo list($repos), timeUnit(month), timeInterval($months), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport)"
+                artifactCleanup( "month", months, repos, log, paceTimeMS, dryRun, disablePropertiesSupport )
+            }
         }
     }
+
 }
 
-private def artifactCleanup(int months, String[] repos, log, paceTimeMS, dryRun = false, disablePropertiesSupport = false) {
-    log.info "Starting artifact cleanup for repositories $repos, until $months months ago with pacing interval $paceTimeMS ms, dryrun: $dryRun, disablePropertiesSupport: $disablePropertiesSupport"
+if ( configFile.exists() ) {
+  
+    def config = new JsonSlurper().parse(configFile.toURL())
+    log.info "Schedule job policy list: $config.policies"
+
+    config.policies.each{ policySettings ->
+        def cron = policySettings.containsKey("cron") ? policySettings.cron as String : ["0 0 5 ? * 1"]
+        def repos = policySettings.containsKey("repos") ? policySettings.repos as String[] : ["__none__"]
+        def timeUnit = policySettings.containsKey("timeUnit") ? policySettings.timeUnit as String : DEFAULT_TIME_UNIT
+        def timeInterval = policySettings.containsKey("timeInterval") ? policySettings.timeInterval as int : DEFAULT_TIME_INTERVAL
+        def paceTimeMS = policySettings.containsKey("paceTimeMS") ? policySettings.paceTimeMS as int : 0
+        def dryRun = policySettings.containsKey("dryRun") ? new Boolean(policySettings.dryRun) : false
+        def disablePropertiesSupport = policySettings.containsKey("disablePropertiesSupport") ? new Boolean(policySettings.disablePropertiesSupport) : false
+
+        jobs {
+            "scheduledCleanup_$cron"(cron: cron) {
+                log.info "Policy settings for scheduled run at($cron): repo list($repos), timeUnit($timeUnit), timeInterval($timeInterval), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport)"
+                artifactCleanup( timeUnit, timeInterval, repos, log, paceTimeMS, dryRun, disablePropertiesSupport )
+            }
+        }
+    }  
+}
+
+if ( deprecatedConfigFile.exists() && configFile.exists() ) {
+    log.info "The deprecated artifactCleanup.properties and the new artifactCleanup.json are defined in parallel. You should migrate the old file and remove it."
+}
+
+private def artifactCleanup(String timeUnit, int timeInterval, String[] repos, log, paceTimeMS, dryRun = false, disablePropertiesSupport = false) {
+    log.info "Starting artifact cleanup for repositories $repos, until $timeInterval ${timeUnit}s ago with pacing interval $paceTimeMS ms, dryrun: $dryRun, disablePropertiesSupport: $disablePropertiesSupport"
 
     // Create Map(repo, paths) of skiped paths (or others properties supported in future ...)
     def skip = [:]
@@ -106,15 +156,19 @@ private def artifactCleanup(int months, String[] repos, log, paceTimeMS, dryRun 
         skip = getSkippedPaths(repos)
     }
 
-    def monthsUntil = Calendar.getInstance()
-    monthsUntil.add(Calendar.MONTH, -months)
+    def calendarUntil = Calendar.getInstance()
+
+    calendarUntil.add(mapTimeUnitToCalendar(timeUnit), -timeInterval)
+
+    def calendarUntilFormatted = new SimpleDateFormat("yyyy/MM/dd HH:mm").format(calendarUntil.getTime());
+    log.info "Removing all artifacts older than $calendarUntilFormatted"
 
     Global.stopCleaning = false
     int cntFoundArtifacts = 0
     int cntNoDeletePermissions = 0
     long bytesFound = 0
     long bytesFoundWithNoDeletePermission = 0
-    def artifactsCleanedUp = searches.artifactsNotDownloadedSince(monthsUntil, monthsUntil, repos)
+    def artifactsCleanedUp = searches.artifactsNotDownloadedSince(calendarUntil, calendarUntil, repos)
     artifactsCleanedUp.find {
         try {
             while ( Global.pauseCleaning ) {
@@ -217,4 +271,22 @@ private def getSkippedPaths(String[] repos) {
     TimeDuration duration = TimeCategory.minus(timeStop, timeStart)
     log.info "Elapsed time to retrieve paths to skip: " + duration
     return skip
+}
+
+private def mapTimeUnitToCalendar (String timeUnit) {
+    switch ( timeUnit ) {
+        case "minute":
+            return Calendar.MINUTE
+        case "hour":
+            return Calendar.HOUR
+        case "day":
+            return Calendar.DAY_OF_YEAR
+        case "month":
+            return Calendar.MONTH
+        case "year":
+            return Calendar.YEAR
+        default:
+            log.info "$timeUnit is no valid time unit. Falling back to 'month'"
+            return Calendar.MONTH
+    }
 }

--- a/cleanup/artifactCleanup/artifactCleanup.json
+++ b/cleanup/artifactCleanup/artifactCleanup.json
@@ -1,0 +1,15 @@
+{
+    "policies": [
+        {
+            "cron": "0 0 1 ? * 1",
+            "repos": [
+                "libs-releases-local"
+            ],
+            "timeUnit": "day",
+            "timeInterval": 3,
+            "dryRun": true,
+            "paceTimeMS": 500,
+            "disablePropertiesSupport": true
+        }
+    ]
+}


### PR DESCRIPTION
Closes https://github.com/jfrog/artifactory-user-plugins/issues/227

---

**Motivation:**
Until now as time unit only "month" have been supported. This has prevented using the plugin for cleaning up the artifacts that have been not downloaded for e.g. the last 14 days.

**Changes:**
The new parameters `timeUnit` and `timeInterval` are introduced, while the support for the old `months` is still preserved. This allows a far more flexible configuration when artifacts can be deleted. Moreover the cleanup policies for different repositories defined in the `artifactCleanup.properties` are still supported, but there is a new json-based `artifactCleanup.json` introduced that is allowing a way more transparent and extensible policies definition. The introduction of the new file also allows to stay backward compatible and avoids building in not maintainable code. The `README.md` has been updated accordingly to these changes.

**Tests**
The tests have been changed to use the new parameters. The basic test-case was duplicated and uses the deprecated month parameter.

---

This is my first PR for the jFrog user plugin repository. It should be compliant to the rules defined in the `CONTRIBUTING.md`. Nevertheless feel free to give me any feedback to the code quality and style. 