### PR TITLE
deleteByPropertyValue: optional "dryRun" parameter to enable test runs

### DIFF
--- a/cleanup/deleteByPropertyValue/DeleteByPropertyValueTest.groovy
+++ b/cleanup/deleteByPropertyValue/DeleteByPropertyValueTest.groovy
@@ -31,10 +31,39 @@ class DeleteByPropertyValueTest extends Specification {
         thrown(HttpResponseException)
 
         when:
-        repo.file('otherfile').info()
+        def fileInfo = repo.file('otherfile').info()
 
         then:
-        notThrown(HttpResponseException)
+        fileInfo != null
+
+        cleanup:
+        repo?.delete()
+    }
+
+    def 'delete by property value dryRun test'() {
+
+        setup:
+        def baseurl = 'http://localhost:8088/artifactory'
+        def artifactory = ArtifactoryClientBuilder.create().setUrl(baseurl)
+            .setUsername('admin').setPassword('password').build()
+        def builder = artifactory.repositories().builders().localRepositoryBuilder()
+        builder.key('cleanup-local')
+        builder.repositorySettings(new GenericRepositorySettingsImpl())
+        artifactory.repositories().create(0, builder.build())
+        def repo = artifactory.repository('cleanup-local')
+        def somefile = new ByteArrayInputStream('content'.bytes)
+        repo.upload('somefile', somefile).withProperty('someprop', '4').doUpload()
+        def plugin = artifactory.plugins().execute('deleteByPropertyValue')
+        plugin.withParameter('propertyName', 'someprop')
+        plugin.withParameter('propertyValue', '5')
+        plugin.withParameter('repo', 'cleanup-local')
+        plugin.withParameter('dryRun', 'true').sync()
+
+        when:
+        def fileInfo = repo.file('somefile').info()
+
+        then:
+        fileInfo != null
 
         cleanup:
         repo?.delete()

--- a/cleanup/deleteByPropertyValue/README.md
+++ b/cleanup/deleteByPropertyValue/README.md
@@ -14,6 +14,7 @@ Parameters
 - `propertyName`: The property name which you want to search for
 - `propertyValue`: The value of the property, all files with a value lower than this will be deleted
 - `repos`: The repository from which you want to delete artifacts with this property
+- `dryRun`: If set to *true* the artifacts to delete will be logged but not deleted. The parameter is optional. Default: *false*.
 
 To ensure logging for this plugin, edit ${ARTIFACTORY_HOME}/etc/logback.xml to add:
 ```xml

--- a/cleanup/deleteByPropertyValue/deleteByPropertyValue.groovy
+++ b/cleanup/deleteByPropertyValue/deleteByPropertyValue.groovy
@@ -14,13 +14,14 @@ executions {
         propertyName = params?.get('propertyName')?.get(0) as String
         propertyValue = params?.get('propertyValue')?.get(0) as int
         repo = params?.get('repo')?.get(0) as String
-        fileCleanup(propertyName, propertyValue, repo)
+        dryRun = new Boolean(params?.get('dryRun')?.get(0))
+        fileCleanup(propertyName, propertyValue, repo, dryRun)
     }
 }
 
 
 
-private def fileCleanup(propertyName, propertyValue, repo) {
+private def fileCleanup(propertyName, propertyValue, repo, dryRun) {
     log.info "Looking for files with property of $propertyName with a value lower than $propertyValue... in $repo"
 
     def count = 0
@@ -35,15 +36,17 @@ private def fileCleanup(propertyName, propertyValue, repo) {
             def keyValue = repositories.getProperty(repoPath, propertyName)
             log.info "$propertyName: $keyValue"
             if (keyValue.toInteger() < propertyValue) {
-                log.info "Deleting $repoPath"
-                repositories.delete repoPath
+                log.info "Deleting $repoPath (dryRun: $dryRun)"
+                if (!dryRun) {
+                    repositories.delete repoPath
+                }
                 count++
             }
         }
     }
     if (count > 0){
-        log.info ("Succesfully deleted  " + count + " files")
+        log.info ("Succesfully deleted  $count files (dryRun: $dryRun)")
     } else
-        log.info ("No files with property: '" + propertyName + "' and property value less than '" + propertyValue +"' found. Did not delete anything")
+        log.info ("No files with property: '$propertyName' and property value less than '$propertyValue' found. Did not delete anything")
     status = 200
 }


### PR DESCRIPTION
**Motivation:**
Currently the `dryRun` parameter is supported by the *artifactCleanup* plugin but not by the *deleteByPropertyValue* plugin. It should be avoided to move artifacts to trash accidentally because the recovery creates meta-data and additional trouble that can be avoided easily.

**Changes:**
The pull request introduces the new `dryRun` parameter that is optional. To maintain the backwards compatibility the parameter is `false` by default. The usage of the parameter allows to test what will be deleted before the actual deletion process is performed.

**Tests:**
The tests have been added to use the new parameter. The basic test case was duplicated and modified to test the new parameter. 

---

I'm looking forward to your feedback.