### PR TITLE
Alpine

### DIFF
--- a/repository/alpine/README.md
+++ b/repository/alpine/README.md
@@ -1,15 +1,19 @@
-# Artifactory <Name> User Plugin
+# Artifactory Alpine User Plugin
 
-<Provide a brief description on what this plugins does and the scenarios when it can/should be used.>
+Adds support for Alpine mirror repositories, using the Generic Remote and at a certain interval removing the APK index files.
+
+An alternative approach would be rsync, but this is not supported by Artifactory (and would result in always having a full mirror). This plugin does not remove any old apk packages from cache (which could be a possible improvement).
 
 ## Features
 
-<List and describe in more details the plugin features>
+Very little :). Only removes apk index files at set interval.
 
 ## Installation
 
-<Describe how to get this plugin up and running>
+- Create remote repository of the Generic type, configuring any alpine apk mirror as remote.
+- On the respective cache repository, add a property 'alpine' (value not needed or used).
+- Install plugin as any other plugin, optionally setting the log level to info, and optionally altering the job interval from within the code.
 
 ## Usage
 
-<Describe how to use the features delivered by this plugin>
+Point the client to use Artifactory, following the [Alpine documentation](https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Repository_pinning).

--- a/repository/alpine/README.md
+++ b/repository/alpine/README.md
@@ -1,0 +1,15 @@
+# Artifactory <Name> User Plugin
+
+<Provide a brief description on what this plugins does and the scenarios when it can/should be used.>
+
+## Features
+
+<List and describe in more details the plugin features>
+
+## Installation
+
+<Describe how to get this plugin up and running>
+
+## Usage
+
+<Describe how to use the features delivered by this plugin>

--- a/repository/alpine/alpine.groovy
+++ b/repository/alpine/alpine.groovy
@@ -8,7 +8,7 @@ jobs {
         indexFiles = searches.artifactsByName('APKINDEX.tar.gz', *alpineCaches)
         log.info("Found apk index files that will be deleted: {}", indexFiles)
         indexFiles.each {
-            log.warn("deleting apk index files: {}", it)
+            log.info("Deleting apk index files: {}", it)
             repositories.delete(it)
         }
     }

--- a/repository/alpine/alpine.groovy
+++ b/repository/alpine/alpine.groovy
@@ -9,7 +9,7 @@ import org.artifactory.repo.RepoPathFactory
  * A smaller value will of course produce more server load.
  */
 jobs {
-	deleteApkIndexFiles(delay: 0, interval: 60000) {
+    deleteApkIndexFiles(delay: 0, interval: 60000) {
         alpineRepos = getAlpineRepos()
         alpineCaches = alpineRepos.collect { it.getRepoKey() + '-cache' }
         indexFiles = searches.artifactsByName('APKINDEX.tar.gz', *alpineCaches)
@@ -25,7 +25,7 @@ jobs {
  * Returns a list of local alpine repositories, determined by the existence of the 'alpine' property.
  */
 List<RepoPath> getAlpineRepos() {
-	repositories.getRemoteRepositories()
-		.collect { RepoPathFactory.create(it) }
-		.findAll { repositories.hasProperty(it, 'alpine') }
+    repositories.getRemoteRepositories()
+        .collect { RepoPathFactory.create(it) }
+        .findAll { repositories.hasProperty(it, 'alpine') }
 }

--- a/repository/alpine/alpine.groovy
+++ b/repository/alpine/alpine.groovy
@@ -1,6 +1,13 @@
 import org.artifactory.repo.RepoPath
 import org.artifactory.repo.RepoPathFactory
 
+/**
+ * A CRON job to remove all apk index files from cache repositories marked 'alpine'.
+ * Adjust the interval (in ms) at will. Note that when the interval is large you run a larger
+ * risk for a not found error. This is because the index is cached and presetn, but if the client
+ * requests a non-cached updated file, this will not be present in the upstream.
+ * A smaller value will of course produce more server load.
+ */
 jobs {
 	deleteApkIndexFiles(delay: 0, interval: 60000) {
         alpineRepos = getAlpineRepos()

--- a/repository/alpine/alpine.groovy
+++ b/repository/alpine/alpine.groovy
@@ -1,0 +1,24 @@
+import org.artifactory.repo.RepoPath
+import org.artifactory.repo.RepoPathFactory
+
+jobs {
+	deleteApkIndexFiles(delay: 0, interval: 60000) {
+        alpineRepos = getAlpineRepos()
+        alpineCaches = alpineRepos.collect { it.getRepoKey() + '-cache' }
+        indexFiles = searches.artifactsByName('APKINDEX.tar.gz', *alpineCaches)
+        log.info("Found apk index files that will be deleted: {}", indexFiles)
+        indexFiles.each {
+            log.warn("deleting apk index files: {}", it)
+            repositories.delete(it)
+        }
+    }
+}
+
+/**
+ * Returns a list of local alpine repositories, determined by the existence of the 'alpine' property.
+ */
+List<RepoPath> getAlpineRepos() {
+	repositories.getRemoteRepositories()
+		.collect { RepoPathFactory.create(it) }
+		.findAll { repositories.hasProperty(it, 'alpine') }
+}


### PR DESCRIPTION
Adds support for Alpine mirror repositories, using the Generic Remote and at a certain interval removing the APK index files.

An alternative approach would be rsync, but this is not supported by Artifactory (and would result in always having a full mirror). This plugin does not remove any old apk packages from cache (which could be a possible improvement).