### PR TITLE
Bugfix webhook for sync path

### DIFF
--- a/webhook/webhook.groovy
+++ b/webhook/webhook.groovy
@@ -496,12 +496,12 @@ class WebHook {
             def webhookListeners = triggers.get(event)
             if (webhookListeners) {
                 // We need to do this twice to do all async first
-                for (WebhookEndpointDetails webhook : webhookListeners) {
+                for (WebhookEndpointDetails webhookListener : webhookListeners) {
                     try {
-                        if (webhook.isAsync()) {
+                        if (webhookListener.isAsync()) {
                             if (eventPassedFilters(event, json, webhook))
                                 excutorService.execute(
-                                        new PostTask(webhook.url, getFormattedJSONString(json, event, webhook)))
+                                        new PostTask(webhookListener.url, getFormattedJSONString(json, event, webhookListener)))
                         }
                     } catch (Exception e) {
                         // We don't capture async results
@@ -512,7 +512,7 @@ class WebHook {
                 for (def webhookListener : webhookListeners) {
                     try {
                         if (!webhookListener.isAsync())
-                            if (eventPassedFilters(event, json, webhook))
+                            if (eventPassedFilters(event, json, webhookListener))
                                 callPost(webhookListener.url, getFormattedJSONString(json, webhook))
                     } catch (Exception e) {
                         if (debug)

--- a/webhook/webhook.groovy
+++ b/webhook/webhook.groovy
@@ -499,7 +499,7 @@ class WebHook {
                 for (WebhookEndpointDetails webhookListener : webhookListeners) {
                     try {
                         if (webhookListener.isAsync()) {
-                            if (eventPassedFilters(event, json, webhook))
+                            if (eventPassedFilters(event, json, webhookListener))
                                 excutorService.execute(
                                         new PostTask(webhookListener.url, getFormattedJSONString(json, event, webhookListener)))
                         }
@@ -513,7 +513,7 @@ class WebHook {
                     try {
                         if (!webhookListener.isAsync())
                             if (eventPassedFilters(event, json, webhookListener))
-                                callPost(webhookListener.url, getFormattedJSONString(json, webhook))
+                                callPost(webhookListener.url, getFormattedJSONString(json, event, webhookListener))
                     } catch (Exception e) {
                         if (debug)
                             e.printStackTrace()


### PR DESCRIPTION
i dont believe the original code worked for sync (not sure why you'd use it, but its there so it should be corrected)

there was no 'webhook' in scope for eventPassedFilters(event, json, webhook) on :515-:516 , probably a copy paste error from the async portion above, the variable in scope is webhookListener

also getFormattedJSONString() needs an event which was not provided on line 516, maybe this was added later and relevant code was not updated?

also made variable names in async and sync portion identical to reduce confusion and hopefullly similar errors