### PR TITLE
inactiveServerCleaner: add correct type and cleanup

### DIFF
--- a/ha/inactiveServerCleaner/inactiveServerCleaner.groovy
+++ b/ha/inactiveServerCleaner/inactiveServerCleaner.groovy
@@ -1,9 +1,17 @@
-import org.artifactory.state.ArtifactoryServerState
-import org.artifactory.storage.db.servers.service.ArtifactoryServersCommonService
+import groovy.transform.Field
 import org.artifactory.common.ConstantValues
+import org.artifactory.state.ArtifactoryServerState
+import org.artifactory.storage.db.servers.model.ArtifactoryServer
+import org.artifactory.storage.db.servers.service.ArtifactoryServersCommonService
 import org.slf4j.Logger
 
 import java.util.concurrent.TimeUnit
+
+@Field
+ArtifactoryServersCommonService artifactoryServersCommonService = ctx.beanForType(ArtifactoryServersCommonService)
+
+@Field
+ArtifactoryInactiveServersCleaner artifactoryInactiveServerCleaner = new ArtifactoryInactiveServersCleaner(artifactoryServersCommonService, log)
 
 jobs {
     clean(interval: 90000, delay: 900000) {
@@ -17,13 +25,11 @@ executions {
     }
 }
 
-def runCleanupHAInactiveServers() {
-    def artifactoryServersCommonService = ctx.beanForType(ArtifactoryServersCommonService)
-    def artifactoryInactiveServerCleaner = new ArtifactoryInactiveServersCleaner(artifactoryServersCommonService, log)
+void runCleanupHAInactiveServers() {
     artifactoryInactiveServerCleaner.cleanInactiveArtifactoryServers()
 }
 
-public class ArtifactoryInactiveServersCleaner {
+class ArtifactoryInactiveServersCleaner {
 
     private ArtifactoryServersCommonService artifactoryServersCommonService
     private Logger log
@@ -35,16 +41,15 @@ public class ArtifactoryInactiveServersCleaner {
 
     def cleanInactiveArtifactoryServers() {
         log.info "Executing inactive artifactory servers cleaner plugin"
-        List<String> allMembers = artifactoryServersCommonService.getAllArtifactoryServers()
+        List<ArtifactoryServer> allMembers = artifactoryServersCommonService.getAllArtifactoryServers()
         for (member in allMembers) {
-            def heartbeat = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - member.getLastHeartbeat())
-            def noHeartbeat = heartbeat > ConstantValues.haHeartbeatStaleIntervalSecs.getInt()
-            if (member.getServerState() == ArtifactoryServerState.UNAVAILABLE || ( noHeartbeat && member.getServerState() != ArtifactoryServerState.CONVERTING && member.getServerState() != ArtifactoryServerState.STARTING )) {
+            long heartbeat = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - member.getLastHeartbeat())
+            boolean noHeartbeat = heartbeat > ConstantValues.haHeartbeatStaleIntervalSecs.getInt()
+            if (member.getServerState() == ArtifactoryServerState.UNAVAILABLE || (noHeartbeat && member.getServerState() != ArtifactoryServerState.CONVERTING && member.getServerState() != ArtifactoryServerState.STARTING)) {
                 try {
                     log.info "Inactive artifactory servers cleaning task found server ${member.serverId} to remove"
                     artifactoryServersCommonService.removeServer(member.serverId)
-
-                }catch (Exception e){
+                } catch (Exception e) {
                     log.error "Error: Not able to remove ${member.serverId}, ${e.message}"
                 }
             }


### PR DESCRIPTION
The type was incorrectly put as List<String> instead of List<ArtifactoryServer>. As groovy is not type-safe this works at runtime but fails compilation within an IDE. Also optimises the artifactoryInactiveServerCleaner to be instantiated once and not on each execution. Also added missing imports and removed unnecessary public modifier.

Overall, just general linting changes.