### PR TITLE
ha/inactiveServerCleaner: add grace period after server start

### DIFF
--- a/ha/inactiveServerCleaner/README.md
+++ b/ha/inactiveServerCleaner/README.md
@@ -8,7 +8,9 @@ This plugin implements a job that runs every 90 seconds. The job execution start
 15 minutes after the Artifactory instance comes up.
 
 For every execution, the plugin will get the list on nodes members of the cluster
-and remove the ones that are unavailable.
+and remove the ones that are unavailable. It will skip nodes in the cluster
+that have started within the past 5 minutes, to ensure that nodes that are
+starting are not removed before they fully start.
 
 ## Installation
 


### PR DESCRIPTION
We (Stripe) have configured an Artifactory HA cluster to run in an auto-scaling group. We were seeing issues where replacing a single member of the cluster with the `inactiveServerCleaner` plugin active would randomly fail; we traced this back to the case where a server took longer than 90 seconds to start, which means that this plugin would "clean" the not-yet-booted server.

The fix is to add a grace period to the plugin such that it does nothing when a node in the cluster was started within the past 5 minutes. Additionally, the plugin was rewritten to be more verbose when making decisions, and to make it clearer how the selection logic is implemented.

This is my first PR here, so let me know if there's anything else I need to do! Stripe has signed the JFrog corporate CLA.