### PR TITLE
fixed readme

### DIFF
--- a/cleanup/cleanDockerImages/README.md
+++ b/cleanup/cleanDockerImages/README.md
@@ -15,7 +15,7 @@ The `cleanDockerImages.properties` file has the following field:
 For example:
 
 ``` json
-dockerRepos: ["example-docker-local", "example-docker-local-2"]
+dockerRepos = ["example-docker-local", "example-docker-local-2"]
 ```
 
 Usage


### PR DESCRIPTION
The example in the README.md isn't correct. The **:** should be replaced with a **=**, just as it is in the cleanDockerImages.properties. 