### PR TITLE
Prevent paceTime from becoming sub-zero when adjusted

### DIFF
--- a/cleanup/artifactCleanup/artifactCleanup.groovy
+++ b/cleanup/artifactCleanup/artifactCleanup.groovy
@@ -78,8 +78,9 @@ executions {
                 break
             case "adjustPaceTimeMS":
                 def adjustPaceTimeMS = params['value'] ? params['value'][0] as int : 0
-                Global.paceTimeMS += adjustPaceTimeMS
-                log.info "Pacing adjustment request detected, adjusting pace time by $adjustPaceTimeMS to new value of $Global.paceTimeMS"
+                def newPaceTimeMS = ((Global.paceTimeMS + adjustPaceTimeMS) > 0) ? (Global.paceTimeMS + adjustPaceTimeMS) : 0
+                log.info "Pacing adjustment request detected, adjusting old pace time ($Global.paceTimeMS) by $adjustPaceTimeMS to new value of $newPaceTimeMS"
+                Global.paceTimeMS = newPaceTimeMS
                 break
             case "pause":
                 Global.pauseCleaning = true


### PR DESCRIPTION
Pace time adjustments can cause `Global.paceTimeMS` to dip below zero.  While the sleep block checks for this, it's still inconvenient, as overzealous adjustment attempts can leave the value hard to adjust back to a sane positive value without possibly guessing.

This change checks the proposed value _first_ to prevent the adjusted `Global.paceTimeMS` to never become less than zero.