### PR TITLE
artifactCleanup.groovy Fix default value - repos.

### DIFF
--- a/cleanup/artifactCleanup/artifactCleanup.groovy
+++ b/cleanup/artifactCleanup/artifactCleanup.groovy
@@ -52,7 +52,7 @@ executions {
     cleanup(groups: [pluginGroup]) { params ->
         def timeUnit = params['timeUnit'] ? params['timeUnit'][0] as String : DEFAULT_TIME_UNIT
         def timeInterval = params['timeInterval'] ? params['timeInterval'][0] as int : DEFAULT_TIME_INTERVAL
-        def repos = params['repos'] as String[]
+        def repos = params['repos'] ? params['repos'] as String[] : ["__none__"] as String[]
         def dryRun = params['dryRun'] ? new Boolean(params['dryRun'][0]) : false
         def disablePropertiesSupport = params['disablePropertiesSupport'] ? new Boolean(params['disablePropertiesSupport'][0]) : false
         def paceTimeMS = params['paceTimeMS'] ? params['paceTimeMS'][0] as int : 0


### PR DESCRIPTION
In README.md we have required parameter as "repos", but in fact, you can skip him in different ways,
examples:
```
curl -X POST -u "admin:password" "http://localhost:8081/artifactory/api/plugins/execute/cleanup?params=timeUnit=day;timeInterval=;repos=;dryRun=false;paceTimeMS=0;disablePropertiesSupport=true"
curl -X POST -u "admin:password" "http://localhost:8081/artifactory/api/plugins/execute/cleanup?params=timeUnit=day;timeInterval=;dryRun=false;paceTimeMS=0;disablePropertiesSupport=true"
```
If we dont set this parameter it would affected [all repositories](https://repo.jfrog.org/artifactory/oss-releases-local/org/artifactory/artifactory-papi/7.6.3/artifactory-papi-7.6.3-javadoc.jar!/org/artifactory/search/Searches.html#artifactsNotDownloadedSince(java.util.Calendar,java.util.Calendar,java.lang.String...)) because we hit `searches.artifactsNotDownloadedSince(calendarUntil, calendarUntil, repos)` and parameter "repos" in our situation is null.
It's very dangerous case, because we can easily post curl with parameters from unix system, and forget that we send this post from different users in which case parameters is empty, and we can delete all artifacts(depends on time limits)

I applyed fix similar to config file, but can easily rewrite it to something like - no parameter or bad "repos" send 400 Error, and add ability to set __all__ in repos for get all repos.