### PR TITLE
Internal users aka tech user should not be checked for groups in the LDAP

### DIFF
--- a/security/synchronizeLdapGroups/synchronizeLdapGroups.groovy
+++ b/security/synchronizeLdapGroups/synchronizeLdapGroups.groovy
@@ -31,6 +31,9 @@ realms {
                 || username ==~ /^token:jf[a-z]+@01e[a-z0-9]{23}$/) {
                 return true
             }
+            if (user.realm == 'internal') {
+                return true
+            }
             def settings = new LdapGroupsSettings()
             // 'il-users' is an existing Ldap Group Setting Name in Artifactory
             // All the permissions given to the group will be inherited by the user


### PR DESCRIPTION
internal users (aka tech user) should not be checked in the LDAP. There is no entry and this triggers an unnecessary trip to the LDAP server. In your case, it triggered the timeout resulting in noticeable lag in the UI.