### PR TITLE
Reduce Incorrect User Calls to LDAP

### DIFF
--- a/security/synchronizeLdapGroups/synchronizeLdapGroups.groovy
+++ b/security/synchronizeLdapGroups/synchronizeLdapGroups.groovy
@@ -27,8 +27,8 @@ realms {
     myrealm([autoCreateUsers: false, realmPolicy: RealmPolicy.ADDITIVE]) {
         authenticate { username, credentials ->
             // Common special or internal users can be skipped
-            if (username in ['anonymous', '_internal', 'xray', 'access-admin', 'admin', 'jffe@000']
-                || username ==~ /^token:jf[a-z]+@01e[a-z0-9]{23}$/) {
+            if (username in ['anonymous', '_internal', 'xray', 'access-admin', 'admin', 'jffe@000', '_system_']
+                || username ==~ /^token:jf[a-z]+@[a-z0-9-]+$/) {
                 return true
             }
             def settings = new LdapGroupsSettings()


### PR DESCRIPTION
Reduce incorrect user calls to LDAP:
- Add the '_system_' users to ignored users
- Expand / fix the regular expression definition of a token (currently many tokens don't match, e.g. due to the lack of a dash in the regular expression)