### PR TITLE
"artifactCleanup" add default value for "repos"

### DIFF
--- a/cleanup/artifactCleanup/artifactCleanup.groovy
+++ b/cleanup/artifactCleanup/artifactCleanup.groovy
@@ -52,7 +52,7 @@ executions {
     cleanup(groups: [pluginGroup]) { params ->
         def timeUnit = params['timeUnit'] ? params['timeUnit'][0] as String : DEFAULT_TIME_UNIT
         def timeInterval = params['timeInterval'] ? params['timeInterval'][0] as int : DEFAULT_TIME_INTERVAL
-        def repos = params['repos'] as String[]
+        def repos = params['repos'] as String[] : ["__none__"]
         def dryRun = params['dryRun'] ? new Boolean(params['dryRun'][0]) : false
         def disablePropertiesSupport = params['disablePropertiesSupport'] ? new Boolean(params['disablePropertiesSupport'][0]) : false
         def paceTimeMS = params['paceTimeMS'] ? params['paceTimeMS'][0] as int : 0
@@ -141,6 +141,8 @@ if ( configFile.exists() ) {
         def paceTimeMS = policySettings.containsKey("paceTimeMS") ? policySettings.paceTimeMS as int : 0
         def dryRun = policySettings.containsKey("dryRun") ? new Boolean(policySettings.dryRun) : false
         def disablePropertiesSupport = policySettings.containsKey("disablePropertiesSupport") ? new Boolean(policySettings.disablePropertiesSupport) : false
+        
+        
 
         jobs {
             "scheduledCleanup_$count"(cron: cron) {


### PR DESCRIPTION
According to the doc the following statement should be fulfilled:

repos: A list of repositories to clean. This parameter is required.

Currently this is not the case, which is a major issue that can cause significant damage.