### PR TITLE
webhook: Create a formatter for keel.sh

### DIFF
--- a/webhook/README.md
+++ b/webhook/README.md
@@ -136,8 +136,30 @@ Webhook Formatters
 -----------------
 
 * default - The default formatter
+* keel - A POST formatted specifically for keel.sh
 * slack - A POST formatted specifically for Slack
 * spinnaker - A POST formatted specifically for Spinnaker
+
+### Using the keel format
+
+In order to work with keel format, you need to set your docker registry url in your config file
+( to be prepended to the image name + tag in the webhook)
+
+```json
+{
+  "webhooks": {
+    "keel": {
+        "url": "https://keel.example.com/v1/webhooks/native",
+        "events": [
+          "docker.tagCreated"
+        ],
+        "format": "keel"
+    }
+  }
+  "dockerRegistryUrl": "docker-registry.example.com"
+}
+
+```
 
 #### Using the slack format
 

--- a/webhook/webhook.groovy
+++ b/webhook/webhook.groovy
@@ -316,8 +316,14 @@ class KeelFormatter {
     def format(String event, JsonBuilder data) {
         def builder = new JsonBuilder()
         def json = data.content
+        def imagePath 
+        if (WebHook.dockerRegistryUrl()) {
+          imagePath = "${WebHook.dockerRegistryUrl()}/${json.docker.image}"
+        } else {
+          imagePath = "${WebHook.baseUrl()}/${json.repoKey}/${json.docker.image}"
+        }
         builder {
-          name "${WebHook.dockerRegistryUrl()}/${json.docker.image}"
+          name "${imagePath}"
           tag json.docker.tag
         }
         return builder

--- a/webhook/webhook.groovy
+++ b/webhook/webhook.groovy
@@ -77,6 +77,9 @@ class Globals {
         default: [
             description: "The default formatter", formatter: new ResponseFormatter ( )
         ],
+        keel: [
+            description: "A POST formatted specifically for keel.sh", formatter: new KeelFormatter ( )
+        ],
         slack: [
             description: "A POST formatted specifically for Slack", formatter: new SlackFormatter ( )
         ],
@@ -301,6 +304,21 @@ class ResponseFormatter {
                     event: event,
                     data: data.content
             )
+        }
+        return builder
+    }
+}
+
+/**
+ * Keel formatter
+ */
+class KeelFormatter {
+    def format(String event, JsonBuilder data) {
+        def builder = new JsonBuilder()
+        def json = data.content
+        builder {
+          name "${WebHook.dockerRegistryUrl()}/${json.docker.image}"
+          tag json.docker.tag
         }
         return builder
     }
@@ -538,6 +556,7 @@ class WebHook {
     def debug = false
     def connectionTimeout = 15000
     def baseUrl
+    def dockerRegistryUrl
     def ctx = null
     def log = null
     // Used for async POSTS
@@ -580,6 +599,14 @@ class WebHook {
      */
     static String baseUrl() {
         return me.baseUrl
+    }
+
+    /**
+     * Get the dockerRegistryUrl value
+     * @return value if the dockerRegistryUrl value is set
+     */
+    static String dockerRegistryUrl() {
+        return me.dockerRegistryUrl
     }
 
     /**
@@ -794,6 +821,9 @@ class WebHook {
             // BaseUrl
             if (config.containsKey("baseurl"))
                 me.baseUrl = config.baseurl
+            // DockerRegistryUrl
+            if (config.containsKey("dockerRegistryUrl"))
+                me.dockerRegistryUrl = config.dockerRegistryUrl
         }
     }
 


### PR DESCRIPTION
This PR creates a dedicated [keel](https://keel.sh) formatter for the webhook plugin.