### PR TITLE
Fix capitalization of Docker labels according to guidelines

### DIFF
--- a/cleanup/cleanDockerImages/README.md
+++ b/cleanup/cleanDockerImages/README.md
@@ -24,17 +24,17 @@ Usage
 Cleanup policies are specified as labels on the Docker image. Currently, this
 plugin supports the following policies:
 
-- `maxDays`: The maximum number of days a Docker image can exist in an
+- `maxdays`: The maximum number of days a Docker image can exist in an
   Artifactory repository. Any images older than this will be deleted.
-- `maxCount`: The maximum number of versions of a particular image which should
-  exist. For example, if there are 10 versions of a Docker image and `maxCount`
+- `maxcount`: The maximum number of versions of a particular image which should
+  exist. For example, if there are 10 versions of a Docker image and `maxcount`
   is set to 6, the oldest 4 versions of the image will be deleted.
 
 To set these labels for an image, add them to the Dockerfile before building:
 
 ``` dockerfile
-LABEL com.jfrog.artifactory.retention.maxCount="10"
-LABEL com.jfrog.artifactory.retention.maxDays="7"
+LABEL com.jfrog.artifactory.retention.maxcount="10"
+LABEL com.jfrog.artifactory.retention.maxdays="7"
 ```
 
 When a Docker image is deployed, Artifactory will automatically create

--- a/cleanup/cleanDockerImages/cleanDockerImages.groovy
+++ b/cleanup/cleanDockerImages/cleanDockerImages.groovy
@@ -105,7 +105,7 @@ def simpleTraverse(parentInfo, oldSet, imagesPathMap, imagesCount) {
 // This method checks if the docker image's manifest has the property
 // "com.jfrog.artifactory.retention.maxDays" for purge
 def checkDaysPassedForDelete(item) {
-    def maxDaysProp = "docker.label.com.jfrog.artifactory.retention.maxDays"
+    def maxDaysProp = "docker.label.com.jfrog.artifactory.retention.maxdays"
     def oneday = TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS)
     def prop = repositories.getProperty(item.repoPath, maxDaysProp)
     if (!prop) return false
@@ -118,7 +118,7 @@ def checkDaysPassedForDelete(item) {
 // This method checks if the docker image's manifest has the property
 // "com.jfrog.artifactory.retention.maxCount" for purge
 def getMaxCountForDelete(item) {
-    def maxCountProp = "docker.label.com.jfrog.artifactory.retention.maxCount"
+    def maxCountProp = "docker.label.com.jfrog.artifactory.retention.maxcount"
     def prop = repositories.getProperty(item.repoPath, maxCountProp)
     if (!prop) return 0
     log.debug "PROPERTY $maxCountProp FOUND = $prop IN MANIFEST FILE"


### PR DESCRIPTION
Labels inside Docker images shouldn't contain upper case letters according to the Docker guidelines: https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations
Also, when using Hadolint this leads to an error (which can lead to failing pipelines) unless ignored: https://github.com/hadolint/hadolint/wiki/DL3048