### PR TITLE
Update uniqueNuget Plugin and test

### DIFF
--- a/storage/uniqueNugetDeploy/setup.groovy
+++ b/storage/uniqueNugetDeploy/setup.groovy
@@ -1,5 +1,4 @@
 artifactory 8088, {
   plugin 'storage/uniqueNugetDeploy'
-  dependency 'com.sun.jersey:jersey-core:1.19.4'
   sed 'UniqueNugetDeployTest.groovy', /remote.url\('http:\/\/localhost:/, "remote.url(\'http://$localhost:"
 }

--- a/storage/uniqueNugetDeploy/test/UniqueNugetDeployTest.groovy
+++ b/storage/uniqueNugetDeploy/test/UniqueNugetDeployTest.groovy
@@ -12,17 +12,19 @@ class UniqueNugetDeployTest extends Specification {
         def artifactory = ArtifactoryClientBuilder.create().setUrl(baseurl)
             .setUsername('admin').setPassword('password').build()
 
+        NugetRepositorySettingsImpl settings = new NugetRepositorySettingsImpl()
+	settings.setDownloadContextPath("Download")
         def builder = artifactory.repositories().builders()
         def local = builder.localRepositoryBuilder().key('nuget-local')
-        .repositorySettings(new NugetRepositorySettingsImpl()).build()
+        .repositorySettings(settings).build()
         artifactory.repositories().create(0, local)
 
         def far = builder.localRepositoryBuilder().key('nuget-far')
-        .repositorySettings(new NugetRepositorySettingsImpl()).build()
+        .repositorySettings(settings).build()
         artifactory.repositories().create(0, far)
 
         def remote = builder.remoteRepositoryBuilder().key('nuget-remote').username('admin').password('password')
-        remote.repositorySettings(new NugetRepositorySettingsImpl())
+        remote.repositorySettings(settings)
         remote.url('http://localhost:8088/artifactory/api/nuget/nuget-far')
         artifactory.repositories().create(0, remote.build())
         // TODO when creating a nuget repository via the REST API, the

--- a/storage/uniqueNugetDeploy/uniqueNugetDeploy.groovy
+++ b/storage/uniqueNugetDeploy/uniqueNugetDeploy.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import com.sun.jersey.core.util.MultivaluedMapImpl
 import org.artifactory.addon.nuget.rest.NuGetRequestContext
 import org.artifactory.addon.nuget.search.delegate.packages.PackageEntryRequestDelegate
 import org.artifactory.exception.CancelException
@@ -86,7 +85,7 @@ storage {
         def urlid = "(Id='$id',Version='$ver')"
         def repoService = ctx.beanForType(InternalRepositoryService.class)
         def ps3 = new LinkedMultiValueMap()
-        def ps4 = new MultivaluedMapImpl()
+        def ps4 = new MultivaluedHashMap()
         def context = new NuGetRequestContext()
         try {
             context.uriInfo = new FakeUriInfo(ps4)
@@ -121,7 +120,7 @@ storage {
                 def nrparams = [workContext, repoKey] as Object[]
                 def newRepo = ngas.newInstance(nrparams)
                 def uri = context.uriInfo
-                def lhparams = [newRepo, uri, null] as Object[]
+                def lhparams = ["GET", newRepo, uri, null] as Object[]
                 def localHandler = nglrh.newInstance(lhparams)
                 response = localHandler.packageEntry(urlid)
             } else if (repo.isReal()) {


### PR DESCRIPTION
Changes in this PR include (1) Fix UniqueNugetDeployTest.groovy to create NuGetRepository with the mandatory field DownloadContextPath (enforced  since Artifactory 7.8.1, see RTFACT-21536). (2) Removed unnecessary imports from com.sun.jersey.core.util.MultivaluedMapImpl and replaced usage of MultivaluedMapImpl with MultivaluedHashMap. (3) fixed constructor arg with additional parameter "GET" for localHandler params.

Artifactory version 7.28 and above required for the plugin to be fully functional.

