### PR TITLE
Fixing PTRENG-2606 , issue#392 for Artifactory 7.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.iml
 
 .DS_Store
+${env.ARTIFACTORY_HOME}/etc/plugins/dummyPlugin.groovy

--- a/migration/artifactoryMigrationHelper/README.md
+++ b/migration/artifactoryMigrationHelper/README.md
@@ -55,15 +55,15 @@ This user plugin moves only repository and artifact data and metadata. If you wi
 
 To install this plugin:
 
-1. Place file `artifactoryMigrationHelper.json` under the master Artifactory server `${ARTIFACTORY_HOME}/etc/plugins`
+1. Place file `artifactoryMigrationHelper.json` under the master Artifactory server `${ARTIFACTORY_HOME}/var/etc/artifactory/plugins`
 2. Edit `artifactoryMigrationHelper.json` file content according to your preferences/environment
-3. Place file `artifactoryMigrationHelper.groovy` under the master Artifactory server `${ARTIFACTORY_HOME}/etc/plugins`
+3. Place file `artifactoryMigrationHelper.groovy` under the master Artifactory server `${ARTIFACTORY_HOME}/var/etc/artifactory/plugins`
 4. Request [user plugins reload](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-ReloadPlugins)
 2. Verify in the system logs that the plugin loaded correctly.
 
 ### Logging
 
-To enable logging, add the following lines to `$ARTIFACTORY_HOME/etc/logback.xml` file. There is no need to restart Artifactory for this change to take effect:
+To enable logging, add the following lines to `$ARTIFACTORY_HOME/var/etc/artifactory/logback.xml` file. There is no need to restart Artifactory for this change to take effect:
 
 ```xml
 <logger name="artifactoryMigrationHelper">


### PR DESCRIPTION
The artifactoryMigrationHelper plugin is unusable in 7.x . There are multiple issues with the plugin now which I have explained with log snippets in [PTRENG-2606 comment](https://jira.jfrog.org/browse/PTRENG-2606?focusedCommentId=277167&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-277167)

1. First of all the repositoryService.localRepoDescriptorByKey(repoKey) API does not exist. Since the plugin uses these internal APIs , @shimib suggested to test with the new localOrFederatedRepoDescriptorByKey API.
2. 
2.With above change  the plugin proceeds further but does not create the repos in the target JDP because "createRemoteArtifactoryRepo(repoKey, repoConfiguration)" API does not add "rclass":"local" in the json request and so fails with
```
{
  "errors" : [ {
    "status" : 400,
    "message" : "No repository class found in configuration"
  } ]
}
```
So none of the local, remote and virtual repos are getting created in the target JPD
3. Then the Plugin continues to add the replication configuration to the local repos on the source JPD to the local repos in target JPD ( though these local repos were not created in target JPD )

The SolEng team  do suggest using this plugin regularly to customers for DR setup based on KB [JFROG ARTIFACTORY: Set up a Disaster Recovery(DR) Instance For Your JFrog Artifactory](https://jfrog.com/knowledge-base/jfrog-artifactory-set-up-a-disaster-recoverydr-instance-for-your-jfrog-artifactory/) .

Hence please review this PR and resolve it after testing, so we can use the artifactoryMigrationHelper plugin in RT 7.x .