### PR TITLE
PgpSign - Added support to repository config

### DIFF
--- a/pgp/pgpSign/README.md
+++ b/pgp/pgpSign/README.md
@@ -6,7 +6,8 @@ passphrase specified in `$ARTIFACTORY_HOME/etc/plugins/pgpSign.properties`, and
 deploys the resulting signature in typical fashion as an .asc file parallel to
 the original artifact.
 
-The plugin will be activated only on repository keys ending with `-local`.
+The plugin will be activated only on local repositories that are defined in `pgpSign.properties`.
+Please note that it is important to list the repositories as a comma-separated list, without parentheses nor quotation marks (",[,]).
 
 Purpose-built to meet the needs of promoting artifacts to Maven Central, i.e.
 not intended in its current form for more general use.

--- a/pgp/pgpSign/pgpSign.groovy
+++ b/pgp/pgpSign/pgpSign.groovy
@@ -51,12 +51,18 @@ storage {
     File secretKeyFile =
         new File(ctx.artifactoryHome.etcDir, props.secretKeyFile)
     char[] passphrase = props.passphrase.toCharArray()
+    String[] repos = props.repositories.trim().split(("\\s*,\\s*"))
+    log.info("Loaded repositories: " + repos)
 
     afterCreate { item ->
         String itemKey = item.repoKey
         String itemPath = item.repoPath.path
-        if (!itemKey.endsWith("-local")) {
-            // Only local should be signed
+        log.debug("item repository: " + item.getRepoKey())
+        log.debug("item repository type: " + repositories.getRepositoryConfiguration(item.getRepoKey()).getType())
+        log.debug("Does list contain: " + (repos.contains(item.getRepoKey())))
+        if (!(repositories.getRepositoryConfiguration(item.getRepoKey()).getType().equals("local") && (repos.contains(item.getRepoKey())))) {
+            log.debug("Item repo is not local or not in list")
+            // Only local that matches name from "repos" should be signed
             return
         } else if (item.isFolder()) {
             log.debug("Ignoring creation of new folder: ${itemKey}:${itemPath}")

--- a/pgp/pgpSign/pgpSign.properties
+++ b/pgp/pgpSign/pgpSign.properties
@@ -1,2 +1,3 @@
 secretKeyFile = plugins/pgpSign.key
 passphrase = password
+repositories = test-repo, test2-repo


### PR DESCRIPTION
Updated the user plugin, will support all local repositories that are defined in the pgpSign.properties file, instead of all repositories ending with "-local".