### PR TITLE
expireFilesMetadata: Fix delay to compare milliseconds and not seconds

### DIFF
--- a/metadata/expireFilesMetadata/expireFilesMetadata.groovy
+++ b/metadata/expireFilesMetadata/expireFilesMetadata.groovy
@@ -64,9 +64,10 @@ download {
     beforeDownloadRequest { Request request, RepoPath repoPath ->
         config.repositories.each{ repoName, repoConfig ->
             if (repoName == repoPath.repoKey) {
+                long delayMilliseconds = repoConfig.delay * 1000
                 repoConfig.patterns.each { pattern ->
                     PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
-                    if (isRemote(repoPath.repoKey) && isGeneric(repoPath.repoKey) && shouldExpire(repoPath, repoConfig.delay)) {
+                    if (isRemote(repoPath.repoKey) && isGeneric(repoPath.repoKey) && shouldExpire(repoPath, delayMilliseconds)) {
                         if (matcher.matches(Paths.get(repoPath.path))){
                             log.debug "Expiring " + pattern
                             expired = true


### PR DESCRIPTION
lastUpdated value is in milliseconds but gets compared to a delay in seconds. The fix is changing repoConfig.delay to millisecons also.