### PR TITLE
Update filestoreIntegrity.groovy

### DIFF
--- a/filestore/filestoreIntegrity/filestoreIntegrity.groovy
+++ b/filestore/filestoreIntegrity/filestoreIntegrity.groovy
@@ -1,5 +1,5 @@
 import groovy.json.JsonBuilder
-import org.artifactory.storage.db.binstore.dao.BinariesDao
+import org.jfrog.storage.binstore.db.dao.BinariesDao
 
 executions {
   // Check the integrity of the filestore. This REST endpoint returns a JSON


### PR DESCRIPTION
We are encountering this error in Artifactory 7.49.5

file:/opt/jfrog/artifactory/var/etc/artifactory/plugins/filestoreIntegrity.groovy: 2: unable to resolve class org.artifactory.storage.db.binstore.dao.BinariesDao
 @ line 2, column 1.
   import org.artifactory.storage.db.binstore.dao.BinariesDao

Now, we must use this new path as following.
import org.jfrog.storage.binstore.db.dao.BinariesDao