### PR TITLE
Added a proper unit conversion for delay input variable

### DIFF
--- a/deprecated-plugins/metadata/expireFilesMetadata/expireFilesMetadata.groovy
+++ b/deprecated-plugins/metadata/expireFilesMetadata/expireFilesMetadata.groovy
@@ -104,6 +104,9 @@ def shouldExpire(RepoPath repoPath, long expire) {
     ItemInfo itemInfo = repositories.getItemInfo(repoPath)
     long cacheAge = getCacheAge(itemInfo)
 
+    // Convert expire from seconds to miliseconds to match cacheAge
+    expire = expire * 1000
+    log.info "Delay from expired files metadata plugin: " + expire
     return cacheAge > expire || cacheAge == -1
 }
 

--- a/deprecated-plugins/metadata/expireFilesMetadata/test/ExpireFilesMetadataTest.groovy
+++ b/deprecated-plugins/metadata/expireFilesMetadata/test/ExpireFilesMetadataTest.groovy
@@ -54,7 +54,7 @@ class ExpireFilesMetadataTest extends Specification {
                 '           "patterns": ["**/*.jar"]' +
                 '       },' +
                 '       "msys2-remote": {' +
-                '           "delay": 1800,' +
+                '           "delay": 30,' +
                 '           "patterns": ["**/*.db", "**/*.xz*", "**/*.sig"]' +
                 '       }' +
                 '   }' +
@@ -73,6 +73,7 @@ class ExpireFilesMetadataTest extends Specification {
         // Perform first download request
         def infoFirstDownloadRequest =  downloadAndGetInfo(remote, virtual, packagesPath)
         // Perform second download request
+        sleep(2000l)
         def infoSecondDownloadRequest = downloadAndGetInfo(remote, virtual, packagesPath)
 
         then:


### PR DESCRIPTION
Added a proper unit for input delay variable to convert it from seconds to milliseconds.

Changed existing test to catch this unit conversion mistake if it happens again
