### PR TITLE
Added try catch in deleteEmptyDirsRecursively

### DIFF
--- a/cleanup/deleteEmptyDirs/deleteEmptyDirs.groovy
+++ b/cleanup/deleteEmptyDirs/deleteEmptyDirs.groovy
@@ -86,7 +86,13 @@ def deleteEmptyDirsRecursively(RepoPath path) {
         if (repositories.getChildren(path).empty) {
             // it is folder, and no children - delete!
             log.info "Deleting empty directory($path)"
-            repositories.delete path
+            
+            try {
+                repositories.delete path
+            } catch (Exception e) {
+                log.error "Failed to delete empty directory($path): $e.message"
+            }
+
             deletedDirs += 1
         }
     }


### PR DESCRIPTION
try catch surrounding 'repositories.delete path' so that the process does not stop when an exception is raised